### PR TITLE
Codex

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model Task {
   id                String    @id @default(cuid())
   title             String
   description       String?
-  status            String    @default("pending") // pending, in_progress, completed
+  status            String    @default("pending") // pending, in_progress, completed, canceled
   estimatedPomodoros Int      @default(1)
   completedPomodoros Int      @default(0)
   projectId         String

--- a/src/lib/server/features/task/command/cancel-task/core.ts
+++ b/src/lib/server/features/task/command/cancel-task/core.ts
@@ -1,0 +1,4 @@
+export type CancelTaskCommandInput = {
+  taskId: string;
+  userId: string;
+};

--- a/src/lib/server/features/task/command/cancel-task/handler.ts
+++ b/src/lib/server/features/task/command/cancel-task/handler.ts
@@ -1,0 +1,29 @@
+import type { Task } from '../../core/task';
+import type { CancelTaskCommandInput } from './core';
+import { canCancelTask } from '../../policy/taskPolicy';
+import { TaskRepositoryPrisma } from '../../../../adapter/repository/taskRepository.prisma';
+
+const taskRepository = new TaskRepositoryPrisma();
+
+export async function cancelTask(input: CancelTaskCommandInput): Promise<Task> {
+  // タスクの取得
+  const task = await taskRepository.findById(input.taskId);
+  if (!task) {
+    throw new Error('タスクが見つかりません');
+  }
+
+  // 所有者確認
+  if (task.userId !== input.userId) {
+    throw new Error('このタスクを更新する権限がありません');
+  }
+
+  // 中止可能か確認
+  if (!canCancelTask(task)) {
+    throw new Error('タスクを中止できません');
+  }
+
+  // ステータス更新
+  const updatedTask = await taskRepository.updateStatus(input.taskId, 'canceled');
+
+  return updatedTask;
+}

--- a/src/lib/server/features/task/command/toggle-task-status/handler.ts
+++ b/src/lib/server/features/task/command/toggle-task-status/handler.ts
@@ -23,7 +23,7 @@ export async function toggleTaskStatus(input: ToggleTaskStatusCommandInput): Pro
   }
 
   // ステータスのトグル
-  const newStatus = task.status === 'completed' ? 'pending' : 'completed';
+  const newStatus = (task.status === 'completed' || task.status === 'canceled') ? 'pending' : 'completed';
   const completedAt = newStatus === 'completed' ? new Date() : undefined;
 
   // タスクの更新

--- a/src/lib/server/features/task/core/task.ts
+++ b/src/lib/server/features/task/core/task.ts
@@ -1,4 +1,4 @@
-export type TaskStatus = 'pending' | 'in_progress' | 'completed';
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'canceled';
 
 export type Task = Readonly<{
   id: string;

--- a/src/lib/server/features/task/policy/taskPolicy.ts
+++ b/src/lib/server/features/task/policy/taskPolicy.ts
@@ -2,9 +2,10 @@ import type { Task, TaskStatus } from '../core/task';
 
 export function canTransitionStatus(currentStatus: TaskStatus, newStatus: TaskStatus): boolean {
   const validTransitions: Record<TaskStatus, TaskStatus[]> = {
-    pending: ['in_progress'],
-    in_progress: ['pending', 'completed'],
-    completed: ['pending'],
+    pending: ['in_progress', 'canceled'],
+    in_progress: ['pending', 'completed', 'canceled'],
+    completed: ['pending', 'canceled'],
+    canceled: ['pending']
   };
 
   return validTransitions[currentStatus].includes(newStatus);
@@ -29,4 +30,9 @@ export function canDeleteTask(task: Task): boolean {
 
 export function canToggleStatus(task: Task): boolean {
   return task.status !== 'in_progress'; // 進行中のタスクは直接完了にできない
+}
+
+export function canCancelTask(task: Task): boolean {
+  // 未着手または進行中のタスクを中止できる
+  return task.status === 'pending' || task.status === 'in_progress';
 }

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -6,6 +6,7 @@ import { createTaskWithProject } from '$lib/server/flows/create-task-with-projec
 import { toggleTaskStatus } from '$lib/server/features/task/command/toggle-task-status/handler';
 import { startPomodoroForTask } from '$lib/server/flows/start-pomodoro-for-task/handler';
 import { completeSession } from '$lib/server/features/pomodoro-session/command/complete-session/handler';
+import { cancelTask } from '$lib/server/features/task/command/cancel-task/handler';
 import { PomodoroSessionRepositoryPrisma } from '$lib/server/adapter/repository/pomodoroSessionRepository.prisma';
 import { fail } from '@sveltejs/kit';
 import { getAuthUser } from '$lib/server/auth';
@@ -93,6 +94,24 @@ export const actions: Actions = {
 
 		try {
 			await toggleTaskStatus({ taskId, userId });
+			return { success: true };
+		} catch (error) {
+			if (error instanceof Error) {
+				return fail(400, { error: error.message });
+			}
+			throw error;
+		}
+	},
+	cancelTask: async (event) => {
+		const user = await getAuthUser(event);
+		if (!user) return fail(401, { error: '認証が必要です' });
+
+		const data = await event.request.formData();
+		const taskId = data.get('taskId') as string;
+		const userId = user.id;
+
+		try {
+			await cancelTask({ taskId, userId });
 			return { success: true };
 		} catch (error) {
 			if (error instanceof Error) {

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -213,7 +213,7 @@
 							<div class="p-4 border rounded-lg">
 								<div class="flex justify-between items-start">
 									<div class="flex-1">
-										<h3 class="font-semibold">{task.title}</h3>
+										<h3 class="font-semibold" class:line-through={task.status === 'canceled'} class:text-gray-400={task.status === 'canceled'}>{task.title}</h3>
 										{#if task.description}
 											<p class="text-sm text-gray-600 mt-1">{task.description}</p>
 										{/if}
@@ -227,10 +227,10 @@
 										</div>
 									</div>
 									<div class="flex items-center space-x-2">
-										{#if task.status !== 'completed' && !activeSession}
+									{#if task.status !== 'completed' && task.status !== 'canceled' && !activeSession}
 											<form method="POST" action="?/startPomodoro" use:enhance>
 												<input type="hidden" name="taskId" value={task.id} />
-												<button
+										<button
 													type="submit"
 													class="text-green-600 hover:text-green-900"
 												>
@@ -244,9 +244,20 @@
 												type="submit"
 												class="text-indigo-600 hover:text-indigo-900"
 											>
-												{task.status === 'completed' ? '未完了に戻す' : '完了'}
+											{task.status === 'completed' || task.status === 'canceled' ? '未完了に戻す' : '完了'}
 											</button>
-										</form>
+									</form>
+									{#if task.status !== 'completed' && task.status !== 'canceled'}
+									<form method="POST" action="?/cancelTask" use:enhance>
+										<input type="hidden" name="taskId" value={task.id} />
+										<button
+											type="submit"
+											class="text-red-600 hover:text-red-900"
+										>
+											中止
+										</button>
+									</form>
+									{/if}
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
## Summary
- タスクに「キャンセル」ステータスを追加し、未着手または進行中のタスクを中止できる機能を実装
- キャンセルされたタスクは打ち消し線で表示され、ステータスを未完了に戻すことも可能

## Test plan
- [ ] タスクの「中止」ボタンをクリックして、タスクがキャンセルされることを確認
- [ ] キャンセルされたタスクが打ち消し線で表示されることを確認
- [ ] キャンセルされたタスクを「未完了に戻す」ボタンで復元できることを確認
- [ ] 完了済みタスクには「中止」ボタンが表示されないことを確認

