### PR TITLE
タスクステータスに「中止(cancelled)」を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,7 @@ model Task {
   id                String    @id @default(cuid())
   title             String
   description       String?
-  status            String    @default("pending") // pending, in_progress, completed
+  status            String    @default("pending") // pending, in_progress, completed, cancelled
   estimatedPomodoros Int      @default(1)
   completedPomodoros Int      @default(0)
   projectId         String

--- a/src/lib/server/features/task/core/task.ts
+++ b/src/lib/server/features/task/core/task.ts
@@ -1,4 +1,4 @@
-export type TaskStatus = 'pending' | 'in_progress' | 'completed';
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
 
 export type Task = Readonly<{
   id: string;


### PR DESCRIPTION
## Summary
タスクの状態管理を改善するため、新しいステータス「cancelled」を追加しました。

## Changes
- TaskStatus型に'cancelled'を追加
- Prismaスキーマのコメントを更新

🤖 Generated with [Claude Code](https://claude.ai/code)